### PR TITLE
Adds reference to Passkey Origin Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [WebAuthn Playground](https://opotonniee.github.io/webauthn-playground/) - A web page (no server) to test WebAuthn operations with configurable parameters, and view/parse responses.
 - [Passkeys Debugger](https://www.passkeys-debugger.io/) - A simple website to test different passkeys / WebAuthn server settings and client responses.
 - [Martin Paljak: YAFU - Yet Another FIDO Utility](https://github.com/martinpaljak/YAFU) - Java library and CLI utility for working with CTAP devices over USBHID and NFC
+- [Passkey Origin Validator](https://github.com/developmeh/passkey-origin-validator) - CLI to verify Passkey Related Origin Request .well-known/webauthn configuration, shows label counts and origin matching.
   
 ## Specifications
 - [FIDO latest specifications](https://fidoalliance.org/specifications/download/) - A right place to find most recent & original FIDO specifications.


### PR DESCRIPTION
Passkey Origin Validator implements a go implementation of the chromium webauthn security check for `.well-known/webauthn`

that is hard to verify without a sample implementation and when using multiple related origins verifies certificates and label counts in line with the passkey level 3 working draft